### PR TITLE
Horizon: Added instructions to remove the scrapping mods

### DIFF
--- a/horizon.html
+++ b/horizon.html
@@ -350,6 +350,28 @@ SOFTWARE.
                 Brings BCR's functionality to Horizon's Lever-Action Shotgun.
                 </p>
             </div>
+            <!-- Weapon Scrapping Redone -->
+            <div class="section">
+                <p>
+                <h2 id="weapon_scrap">Weapon Scrapping Redone</h2>
+                <h2 class="install">Instructions:</h2>
+                <ul>
+                    <li>Disable the mod</li>
+                </ul>
+                Not compatible.
+                </p>
+            </div>
+            <!-- Clothing Scrapping Redone -->
+            <div class="section">
+                <p>
+                <h2 id="clothing_scrap">Clothing Scrapping Redone</h2>
+                <h2 class="install">Instructions:</h2>
+                <ul>
+                    <li>Disable the mod</li>
+                </ul>
+                Not compatible.
+                </p>
+            </div>
             <!-- True Invisibility - Horizon Patch -->
             <div class="section">
                 <p>
@@ -494,6 +516,12 @@ SOFTWARE.
                 </li>
                 <li>
                     <a href="#bcr">Bullet Counted Reload</a>
+                </li>
+                <li>
+                    <a href="#weapon_scrap">Weapon Scrapping Redone</a>
+                </li>
+                <li>
+                    <a href="#clothing_scrap">Clothing Scrapping Redone</a>
                 </li>
                 <li>
                     <a href="#invis">True Invisibility</a>


### PR DESCRIPTION
The new scrapping mods are redundant with Horizon. I've sent the updated load order on discord.